### PR TITLE
RunOsort.m: Changed specified data block to plot for raw trace

### DIFF
--- a/code/osortTextUI/RunOSort.m
+++ b/code/osortTextUI/RunOSort.m
@@ -84,7 +84,7 @@ paramsIn.minNrSpikes=100;
                                                                                                                          
 %params
 % for which blocks will a raw figure be made
-paramsIn.blockNrRawFig=[ 100 ];   
+paramsIn.blockNrRawFig=[ 1 ];   
 paramsIn.outputFormat='png';
 % 1=approx, 2=exact
 paramsIn.thresholdMethod=2; 


### PR DESCRIPTION
In order for code to work with sessioneye data, which is much shorter than experiment data, the original specification of plotting raw trace for the 100th block (data sorted in blocks of 512000 samples) does not work. Changed to plot the 1st block instead.