### PR TITLE
Updates to ranked peak detection and realignment

### DIFF
--- a/code/continuous/detectSpikes.m
+++ b/code/continuous/detectSpikes.m
@@ -231,14 +231,14 @@ for i=1:length(searchIndBorders)
             % Store extracted spikes
             if abs(rawSignal(segment_inds(peaks_ranked(jj,2)))) > runningThres
                 covered(counterNeg,1:2) = [fromInd2 toInd2];
-                spikeWaveforms(counterNeg,:) = rawSignal( fromInd2:toInd2 )' ;
+                spikeWaveforms(counterNeg,:) = rawSignal( fromInd2:toInd2 )' ; 
                 spikeTimestamps(counterNeg) = fromInd2+peakInd-1; % HM Edit
 
                 counterNeg=counterNeg+1; %how many spikes extracted so far
                 rawTrace(fromInd2:toInd2)=rawSignal( fromInd2:toInd2 );
                 maxCovered=toInd2;
                 % Adjust list of peaks so there are no overlapping windows
-                % (any other peak in a 45 point time window is excluded)    
+                % (any other peak in a 45 point time window (1.5ms) is excluded)    
 %             inds_overlap = [inds_overlap; find(peaks_ranked(:,2) < peaks_ranked(jj,2)+afterPeak & peaks_ranked(:,2) > peaks_ranked(jj,2)-beforePeak)];
                 inds_overlap = [inds_overlap; find(peaks_ranked(:,2) < peaks_ranked(jj,2)+22 & peaks_ranked(:,2) > peaks_ranked(jj,2)-22)];
             end

--- a/code/continuous/processRaw.m
+++ b/code/continuous/processRaw.m
@@ -156,7 +156,8 @@ for i=startWithBlock:runs
 	spikeWaveformsOrig = spikeWaveforms; %before upsampling
         
     %upsample and re-align
-    % HM Edit - Use this if detecting spikes using peak rank
+    % HM Edit - Use this if detecting spikes using peak rank (this is also
+    % used in posthocWhiten.m
     spikeWaveforms=upsampleSpikes(spikeWaveforms);
     shifted = zeros(1,size(spikeWaveforms,1));
     for jj = 1:size(spikeWaveforms,1)
@@ -254,24 +255,25 @@ blocksProcessed=i;
 
 %whiten
 if size(noiseTraces,1)>0 & size(allSpikesCorrFree,1)>0
-    [trans, transUp, corr, stdWhitened] = posthocWhiten(noiseTraces, allSpikesCorrFree, alignMethod); % HM Edit - edited posthocWhiten to only upsample, without realigning
+    [trans, transUp, corr, stdWhitened] = posthocWhiten(noiseTraces, allSpikesCorrFree, alignMethod); % HM Edit - edited posthocWhiten to 1. only upsample, without realigning, if using original oSort findpeak.m 2. upsample and realign if detecting spikes with peak rank
     allSpikesCorrFree = transUp;   
     
     % HM Edit
     if size(allSpikes,1) ~= size(allSpikesCorrFree,1)
         error('Spike waveforms and Spike waveform (corr free) don''t match in number');
     end
-    for ii = 1:size(allSpikesCorrFree,1)
-        currentSpike = allSpikesCorrFree(ii,:);
-        diff = abs(allShifted(ii));
-        maxPos = 95;
-        if allShifted(ii)<0
-            currentSpike = [currentSpike(1)*ones(1,diff) currentSpike(1:maxPos) currentSpike(maxPos+1:end-diff)]; % HM Edit
-        elseif allShifted(ii)>0
-            currentSpike = [currentSpike(diff+1:maxPos) currentSpike(maxPos+1:end) currentSpike(end)*ones(1,diff)];
-        end
-        allSpikesCorrFree(ii,:) = currentSpike;
-    end
+%     % HM Edit - use this to realign only if using original oSort findpeak.m
+%     for ii = 1:size(allSpikesCorrFree,1)
+%         currentSpike = allSpikesCorrFree(ii,:);
+%         diff = abs(allShifted(ii));
+%         maxPos = 95;
+%         if allShifted(ii)<0
+%             currentSpike = [currentSpike(1)*ones(1,diff) currentSpike(1:maxPos) currentSpike(maxPos+1:end-diff)]; % HM Edit
+%         elseif allShifted(ii)>0
+%             currentSpike = [currentSpike(diff+1:maxPos) currentSpike(maxPos+1:end) currentSpike(end)*ones(1,diff)];
+%         end
+%         allSpikesCorrFree(ii,:) = currentSpike;
+%     end
     
     %only store the autocorrelation,not all noise traces
     noiseTraces=corr;

--- a/code/osortTextUI/RunOSort.m
+++ b/code/osortTextUI/RunOSort.m
@@ -28,8 +28,8 @@ paths.pathRaw = paths.basePath;
 % range(s) of timestamps specified will be processed. 
 paths.timestampspath = paths.basePath;             
 
-% filesToProcessStr = Channel; % HM Edit
-filesToProcessStr = '1'; % HM Edit
+filesToProcessStr = pstr{psend}(end-2:end); % HM Edit
+% filesToProcessStr = '1'; % HM Edit
 %which channels to detect/sort
 filesToProcess = str2double(filesToProcessStr);  
 % which channels to ignore
@@ -56,7 +56,7 @@ paramsIn=[];
 
 % some systems use CSC instead of A
 paramsIn.rawFilePrefix='channel';        
-paramsIn.processedFilePrefix='P';
+paramsIn.processedFilePrefix='Ch';
 
 % see defineFileFormat.m for options
 paramsIn.rawFileVersion = 5; 
@@ -112,26 +112,37 @@ paramsIn.detectionMethod=1;
 dp.kernelSize=18; 
 paramsIn.detectionParams=dp;
 % extraction threshold
-extractionThreshold = 5;  
+extractionThreshold = 6;  
 
 thres = [repmat(extractionThreshold, 1, length(filesToProcess))];
 
 %% Filenames
 
 if isfield(dp,'kernelSize')
-    foldername = [paths.pathRaw filesepchar 'oSort' filesepchar 'detect' ...
-    	num2str(paramsIn.detectionMethod) 'peakType' ...
-    	num2str(paramsIn.peakAlignMethod) 'Align' ...
-    	num2str(paramsIn.defaultAlignMethod) 'Thresh' ...
-    	num2str(extractionThreshold) 'kern' num2str(dp.kernelSize)];
-    dp.kernelSize
+    foldername = [paths.pathRaw filesepchar 'oSort' filesepchar ...
+        'detect' num2str(paramsIn.detectionMethod) ...
+        'Thresh' num2str(extractionThreshold) 'kern' num2str(dp.kernelSize)];
 elseif isfield(dp,'waveletName')
-    foldername = [paths.pathRaw filesepchar 'oSort' filesepchar 'detect' ...
-    	num2str(paramsIn.detectionMethod) dp.waveletName 'peakType' ...
-    	num2str(paramsIn.peakAlignMethod) 'Align' ...
-    	num2str(paramsIn.defaultAlignMethod) 'Thresh' ...
-    	num2str(extractionThreshold)];
+    foldername = [paths.pathRaw filesepchar 'oSort' filesepchar ... 
+        'detect' num2str(paramsIn.detectionMethod) dp.waveletName ...
+        'Thresh' num2str(extractionThreshold)];
 end
+
+% if isfield(dp,'kernelSize')
+%     foldername = [paths.pathRaw filesepchar 'oSort' filesepchar 'detect' ...
+%     	num2str(paramsIn.detectionMethod) 'peakType' ...
+%     	num2str(paramsIn.peakAlignMethod) 'Align' ...
+%     	num2str(paramsIn.defaultAlignMethod) 'Thresh' ...
+%     	num2str(extractionThreshold) 'kern' num2str(dp.kernelSize)];
+%     dp.kernelSize
+% elseif isfield(dp,'waveletName')
+%     foldername = [paths.pathRaw filesepchar 'oSort' filesepchar 'detect' ...
+%     	num2str(paramsIn.detectionMethod) dp.waveletName 'peakType' ...
+%     	num2str(paramsIn.peakAlignMethod) 'Align' ...
+%     	num2str(paramsIn.defaultAlignMethod) 'Thresh' ...
+%     	num2str(extractionThreshold)];
+% end
+
 paths.pathOut=[foldername filesepchar 'sort'];
 paths.pathFigs=[foldername filesepchar 'figs'];
 indDate = strfind(paths.basePath,[filesepchar 'session']);

--- a/code/sortingNew/posthocWhiten.m
+++ b/code/sortingNew/posthocWhiten.m
@@ -42,5 +42,22 @@ stdWhitened=0; %no min/max here (to enforce strict re-alignment regardless of si
 %upsample and re-align
 transUp = upsampleSpikes(trans);
 % transUp = realigneSpikesWhiten(transUp, [], alignMethod, stdWhitened);  % HM Edit
+% HM Edit - realign this way if finding spikes with ranked peaks
+shifted = zeros(1,size(transUp,1));
+for jj = 1:size(transUp,1)
+    spike = transUp(jj,:);
+    % Prevent mistaking of peak at boundaries of block
+    spike_trim = spike;
+    spike_trim(1:90) = 0; spike_trim(100:end) = 0;
+    ind_peak = find(abs(spike_trim) == max(abs(spike_trim)));
+    diff = ind_peak-95;
+    if diff>0
+        transUp(jj,:) = [spike(1+diff:end) repmat(spike(end),1,diff)];
+    elseif diff<0
+        transUp(jj,:) = [repmat(spike(1),1,abs(diff)),spike(1:end-abs(diff))];
+    end
+    shifted(jj) = diff;
+end
+
 
 

--- a/code/sortingNew/sortSpikesOnline.m
+++ b/code/sortingNew/sortSpikesOnline.m
@@ -41,7 +41,7 @@ if nrDatapoints==256
         weights(201:256)=0;
     else
         weights = ones(size(weights,2),1); % Exact threshold - HM Edit (50-150th point only) 
-        weights(1:49,1) = 0;
+        weights(1:74,1) = 0;
         weights(151:end) = 0;
     end
 end


### PR DESCRIPTION
1. RunOSort now labels channels correctly, spike detection threshold set to 6
2. processRaw.m fixed realignment issue for allSpikesCorrFree
3. detectSpikes.m spike overlap window set to 1.5ms (45 points)
4. posthocWhiten.m fixed realignment for upsampled spikes when detecting spikes by peak rank
5. sortSpikesOnline.m sorting window of interest 75-150th point